### PR TITLE
cleanup workflow file

### DIFF
--- a/.github/workflows/pr_validation.workflow.yaml
+++ b/.github/workflows/pr_validation.workflow.yaml
@@ -1,5 +1,5 @@
 name: PR Validation
-run-name: PR ${{ inputs.number }} ${{ inputs.pull_request.number }} ${{ inputs.pull_request.head.ref }} by @${{ github.actor }}
+run-name: PR ${{ github.event.number }} ${{ github.event.pull_request.number }} ${{ github.event.pull_request.head.ref }} by @${{ github.actor }}
 on: pull_request
 
 jobs:

--- a/.github/workflows/pr_validation.workflow.yaml
+++ b/.github/workflows/pr_validation.workflow.yaml
@@ -1,4 +1,5 @@
 name: PR Validation
+run-name: PR \#${{ inputs.number }} {{input.pull_request.head.ref}} by @${{ github.actor }}
 on: pull_request
 
 jobs:

--- a/.github/workflows/pr_validation.workflow.yaml
+++ b/.github/workflows/pr_validation.workflow.yaml
@@ -1,5 +1,5 @@
 name: PR Validation
-run-name: PR \#${{ inputs.number }} {{input.pull_request.head.ref}} by @${{ github.actor }}
+run-name: PR \#${{ inputs.number }} {{ inputs.pull_request.head.ref }} by @${{ github.actor }}
 on: pull_request
 
 jobs:

--- a/.github/workflows/pr_validation.workflow.yaml
+++ b/.github/workflows/pr_validation.workflow.yaml
@@ -1,5 +1,5 @@
 name: PR Validation
-run-name: PR ${{ github.event.number }} ${{ github.event.pull_request.number }} ${{ github.event.pull_request.head.ref }} by @${{ github.actor }}
+run-name: PR \#${{ github.event.number }} \"${{ github.event.pull_request.head.ref }}\" by @${{ github.actor }}
 on: pull_request
 
 jobs:

--- a/.github/workflows/pr_validation.workflow.yaml
+++ b/.github/workflows/pr_validation.workflow.yaml
@@ -1,5 +1,5 @@
 name: PR Validation
-run-name: PR \#${{ inputs.number }} {{ inputs.pull_request.head.ref }} by @${{ github.actor }}
+run-name: PR \#${{ inputs.number }} {{ inputs.pull_request.number }} by @${{ github.actor }}
 on: pull_request
 
 jobs:

--- a/.github/workflows/pr_validation.workflow.yaml
+++ b/.github/workflows/pr_validation.workflow.yaml
@@ -44,4 +44,3 @@ jobs:
         with:
           go-version-file: go.work
       - run: just test
-

--- a/.github/workflows/pr_validation.workflow.yaml
+++ b/.github/workflows/pr_validation.workflow.yaml
@@ -1,5 +1,5 @@
 name: PR Validation
-run-name: ${{ github.event.pull_request.head.ref }} PR#${{ github.event.number }} by @${{ github.actor }}
+run-name: ${{ github.event.pull_request.head.ref }}by @${{ github.actor }}
 on: pull_request
 
 jobs:

--- a/.github/workflows/pr_validation.workflow.yaml
+++ b/.github/workflows/pr_validation.workflow.yaml
@@ -3,7 +3,7 @@ run-name: PR check of ${{ github.event.pull_request.head.ref }} by @${{ github.a
 on: pull_request
 
 jobs:
-  detect-changes:
+  changes:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -20,7 +20,8 @@ jobs:
               - '**/*.go'
 
   lint:
-    needs: detect-changes
+    needs: changes
+    if: ${{ needs.changes.outputs.changes == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
@@ -33,7 +34,8 @@ jobs:
       - run: just lint
 
   test:
-    needs: detect-changes
+    needs: changes
+    if: ${{ needs.changes.outputs.changes == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read

--- a/.github/workflows/pr_validation.workflow.yaml
+++ b/.github/workflows/pr_validation.workflow.yaml
@@ -1,5 +1,5 @@
-name: Go PR Validation
-run-name: GO PR Validator
+name: PR Validation
+run-name: just check (lint, test)
 on: pull_request
 
 jobs:
@@ -9,7 +9,6 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      # FIXME this looks recursive!
       changes: ${{ steps.filter.outputs.changes }}
     steps:
       - uses: actions/checkout@v3
@@ -20,7 +19,7 @@ jobs:
             changes:
               - '**/*.go'
 
-  check-all:
+  lint:
     needs: detect-changes
     runs-on: ubuntu-latest
     permissions:
@@ -30,6 +29,19 @@ jobs:
       - uses: extractions/setup-just@v1
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
-      - run: just check
+          go-version-file: go.work
+      - run: just lint
+
+  test:
+    needs: detect-changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v3
+      - uses: extractions/setup-just@v1
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: go.work
+      - run: just test
 

--- a/.github/workflows/pr_validation.workflow.yaml
+++ b/.github/workflows/pr_validation.workflow.yaml
@@ -1,5 +1,5 @@
 name: PR Validation
-run-name: PR \#${{ inputs.number }} {{ inputs.pull_request.number }} by @${{ github.actor }}
+run-name: PR ${{ inputs.number }} ${{ inputs.pull_request.number }} ${{ inputs.pull_request.head.ref }} by @${{ github.actor }}
 on: pull_request
 
 jobs:

--- a/.github/workflows/pr_validation.workflow.yaml
+++ b/.github/workflows/pr_validation.workflow.yaml
@@ -1,5 +1,5 @@
 name: PR Validation
-run-name: pr#${{ github.event.number }} ${{ github.event.pull_request.head.ref }} by @${{ github.actor }}
+run-name: ${{ github.event.pull_request.head.ref }} PR#${{ github.event.number }} by @${{ github.actor }}
 on: pull_request
 
 jobs:

--- a/.github/workflows/pr_validation.workflow.yaml
+++ b/.github/workflows/pr_validation.workflow.yaml
@@ -1,5 +1,5 @@
 name: PR Validation
-run-name: ${{ github.event.pull_request.head.ref }}by @${{ github.actor }}
+run-name: PR check of ${{ github.event.pull_request.head.ref }} by @${{ github.actor }}
 on: pull_request
 
 jobs:

--- a/.github/workflows/pr_validation.workflow.yaml
+++ b/.github/workflows/pr_validation.workflow.yaml
@@ -1,5 +1,4 @@
 name: PR Validation
-run-name: just check (lint, test)
 on: pull_request
 
 jobs:

--- a/.github/workflows/pr_validation.workflow.yaml
+++ b/.github/workflows/pr_validation.workflow.yaml
@@ -1,5 +1,5 @@
 name: PR Validation
-run-name: PR \#${{ github.event.number }} \"${{ github.event.pull_request.head.ref }}\" by @${{ github.actor }}
+run-name: pr#${{ github.event.number }} ${{ github.event.pull_request.head.ref }} by @${{ github.actor }}
 on: pull_request
 
 jobs:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -24,7 +24,6 @@ linters:
     - gosec
     - importas
     - misspell
-#    - musttag
     - noctx
     - prealloc
     - revive
@@ -32,6 +31,8 @@ linters:
     - unconvert
     - unparam
     - wastedassign
+    # currently broken:
+    # - musttag
 
 linters-settings:
   goimports:

--- a/genum/gen/imports.go
+++ b/genum/gen/imports.go
@@ -52,6 +52,7 @@ func (id ImportDescs) extractTypeRef(t types.Type) string {
 }
 
 // GetActive returns ordered, active imports.
+// Used by templates.
 func (id ImportDescs) GetActive() []ImportDesc {
 	result := make([]ImportDesc, 0, len(id.imports))
 	for _, i := range id.imports {

--- a/justfile
+++ b/justfile
@@ -43,6 +43,7 @@ generate target='all': _tools-generate
 
 # always rebuild the genum executable in this package for testing.
 # other packages should use something like:
+
 # @go install github.com/drshriveer/gtools/genum/genum@{{ GENUM_VERSION }}
 _tools-generate:
     go build -o bin/genum genum/genum/main.go


### PR DESCRIPTION
### Background

Post-merge cleanups.

### Changes

- move musttag to deprecated section
- use go.work file as hint for go version
- rename run-name
- split lint and test tasks
- random comments
- rename changes and include missing conditional

### Testing