### PR TITLE
remove replace directives on buildables

### DIFF
--- a/gencommon/go.mod
+++ b/gencommon/go.mod
@@ -4,8 +4,6 @@ go 1.21.1
 
 require golang.org/x/tools v0.13.0
 
-replace github.com/drshriveer/gtools/set v0.0.0 => ../set
-
 require (
 	golang.org/x/mod v0.12.0 // indirect
 	golang.org/x/sys v0.12.0 // indirect

--- a/genum/go.mod
+++ b/genum/go.mod
@@ -3,18 +3,12 @@ module github.com/drshriveer/gtools/genum
 go 1.21.1
 
 require (
-	github.com/drshriveer/gtools/gencommon v0.0.0
-	github.com/drshriveer/gtools/rutils v0.0.0
-	github.com/drshriveer/gtools/set v0.0.0
+	github.com/drshriveer/gtools/gencommon v0.0.0-20230921080944-8f1b8f9e43fd
+	github.com/drshriveer/gtools/rutils v0.0.0-20230921080944-8f1b8f9e43fd
+	github.com/drshriveer/gtools/set v0.0.0-20230921080944-8f1b8f9e43fd
 	github.com/itzg/go-flagsfiller v1.12.0
 	github.com/stretchr/testify v1.8.4
 	gopkg.in/yaml.v3 v3.0.1
-)
-
-replace (
-	github.com/drshriveer/gtools/gencommon v0.0.0 => ../gencommon
-	github.com/drshriveer/gtools/rutils v0.0.0 => ../rutils
-	github.com/drshriveer/gtools/set v0.0.0 => ../set
 )
 
 require (

--- a/genum/go.sum
+++ b/genum/go.sum
@@ -1,5 +1,11 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/drshriveer/gtools/gencommon v0.0.0-20230921080944-8f1b8f9e43fd h1:LisEEDhhY1ocfXBydiV4A2/8NTFcAlubkjZjcIulnSs=
+github.com/drshriveer/gtools/gencommon v0.0.0-20230921080944-8f1b8f9e43fd/go.mod h1:ER4mobl8fvlqt9fpQSph/LpbiPyNfmR+4QszQrJgcZg=
+github.com/drshriveer/gtools/rutils v0.0.0-20230921080944-8f1b8f9e43fd h1:6IB0DFFI/y9d1faixaze3TLys2YWJ4bMvJJa/Hxk6K0=
+github.com/drshriveer/gtools/rutils v0.0.0-20230921080944-8f1b8f9e43fd/go.mod h1:ixRN41tPraNiLhfegjbhtt9zFLW8XXhZxUlmSaGGU3w=
+github.com/drshriveer/gtools/set v0.0.0-20230921080944-8f1b8f9e43fd h1:v/TVR0hLiWJ+LCxxf4PirDki8o4bvz1EuQPYVwxEHho=
+github.com/drshriveer/gtools/set v0.0.0-20230921080944-8f1b8f9e43fd/go.mod h1:oKjRVsjkkR+xeL/D3IqO/QrSSibcoXYuDapbc46LQyA=
 github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSASxEI=
 github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/itzg/go-flagsfiller v1.12.0 h1:LSwSUGxzZqueprm0D8FBCAG0JMgwAkkh2UjtwreNgAg=

--- a/gerror/go.mod
+++ b/gerror/go.mod
@@ -3,16 +3,11 @@ module github.com/drshriveer/gtools/gerror
 go 1.21.1
 
 require (
-	github.com/drshriveer/gtools/gencommon v0.0.0
-	github.com/drshriveer/gtools/set v0.0.0
+	github.com/drshriveer/gtools/gencommon v0.0.0-20230921080944-8f1b8f9e43fd
+	github.com/drshriveer/gtools/set v0.0.0-20230921080944-8f1b8f9e43fd
 	github.com/fatih/structtag v1.2.0
 	github.com/itzg/go-flagsfiller v1.12.0
 	github.com/stretchr/testify v1.8.4
-)
-
-replace (
-	github.com/drshriveer/gtools/gencommon v0.0.0 => ../gencommon
-	github.com/drshriveer/gtools/set v0.0.0 => ../set
 )
 
 require (

--- a/gerror/go.sum
+++ b/gerror/go.sum
@@ -1,5 +1,9 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/drshriveer/gtools/gencommon v0.0.0-20230921080944-8f1b8f9e43fd h1:LisEEDhhY1ocfXBydiV4A2/8NTFcAlubkjZjcIulnSs=
+github.com/drshriveer/gtools/gencommon v0.0.0-20230921080944-8f1b8f9e43fd/go.mod h1:ER4mobl8fvlqt9fpQSph/LpbiPyNfmR+4QszQrJgcZg=
+github.com/drshriveer/gtools/set v0.0.0-20230921080944-8f1b8f9e43fd h1:v/TVR0hLiWJ+LCxxf4PirDki8o4bvz1EuQPYVwxEHho=
+github.com/drshriveer/gtools/set v0.0.0-20230921080944-8f1b8f9e43fd/go.mod h1:oKjRVsjkkR+xeL/D3IqO/QrSSibcoXYuDapbc46LQyA=
 github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4=
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSASxEI=

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,3 +1,6 @@
+github.com/drshriveer/gtools/gencommon v0.0.0-20230921080944-8f1b8f9e43fd/go.mod h1:ER4mobl8fvlqt9fpQSph/LpbiPyNfmR+4QszQrJgcZg=
+github.com/drshriveer/gtools/rutils v0.0.0-20230921080944-8f1b8f9e43fd/go.mod h1:ixRN41tPraNiLhfegjbhtt9zFLW8XXhZxUlmSaGGU3w=
+github.com/drshriveer/gtools/set v0.0.0-20230921080944-8f1b8f9e43fd/go.mod h1:oKjRVsjkkR+xeL/D3IqO/QrSSibcoXYuDapbc46LQyA=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=

--- a/gsort/go.mod
+++ b/gsort/go.mod
@@ -3,16 +3,11 @@ module github.com/drshriveer/gtools/gsort
 go 1.21.1
 
 require (
-	github.com/drshriveer/gtools/gencommon v0.0.0
-	github.com/drshriveer/gtools/set v0.0.0
+	github.com/drshriveer/gtools/gencommon v0.0.0-20230921080944-8f1b8f9e43fd
+	github.com/drshriveer/gtools/set v0.0.0-20230921080944-8f1b8f9e43fd
 	github.com/fatih/structtag v1.2.0
 	github.com/itzg/go-flagsfiller v1.12.0
 	github.com/stretchr/testify v1.8.4
-)
-
-replace (
-	github.com/drshriveer/gtools/gencommon v0.0.0 => ../gencommon
-	github.com/drshriveer/gtools/set v0.0.0 => ../set
 )
 
 require (

--- a/gsort/go.sum
+++ b/gsort/go.sum
@@ -1,5 +1,9 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/drshriveer/gtools/gencommon v0.0.0-20230921080944-8f1b8f9e43fd h1:LisEEDhhY1ocfXBydiV4A2/8NTFcAlubkjZjcIulnSs=
+github.com/drshriveer/gtools/gencommon v0.0.0-20230921080944-8f1b8f9e43fd/go.mod h1:ER4mobl8fvlqt9fpQSph/LpbiPyNfmR+4QszQrJgcZg=
+github.com/drshriveer/gtools/set v0.0.0-20230921080944-8f1b8f9e43fd h1:v/TVR0hLiWJ+LCxxf4PirDki8o4bvz1EuQPYVwxEHho=
+github.com/drshriveer/gtools/set v0.0.0-20230921080944-8f1b8f9e43fd/go.mod h1:oKjRVsjkkR+xeL/D3IqO/QrSSibcoXYuDapbc46LQyA=
 github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4=
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSASxEI=


### PR DESCRIPTION
### Background

→ Turns out you can't `go install` packages with relative replace directives. That's fine; hopefully we can develop packages individually more often... Still need to come up with some nice just recipes for managing this though.

### Changes

- remove replace directives in all buildable to latest published hash.

### Testing

- existing tests