### PR TITLE
fix extend message bug

### DIFF
--- a/gerror/factory.go
+++ b/gerror/factory.go
@@ -122,7 +122,7 @@ func CloneBase[T factoryOf](
 	}
 
 	// handle message extension:
-	extMsg = strings.TrimPrefix(extMsg, " ")
+	extMsg = strings.TrimSpace(extMsg)
 	if len(extMsg) > 0 {
 		if len(clone.Message) == 0 {
 			clone.Message = extMsg

--- a/gerror/factory.go
+++ b/gerror/factory.go
@@ -1,5 +1,9 @@
 package gerror
 
+import (
+	"strings"
+)
+
 // The Factory interface exposes only methods that can be used for cloning an error.
 // But all errors implement this by default.
 // This allows for dynamic and mutable errors without modifying the base.
@@ -118,8 +122,13 @@ func CloneBase[T factoryOf](
 	}
 
 	// handle message extension:
+	extMsg = strings.TrimPrefix(extMsg, " ")
 	if len(extMsg) > 0 {
-		clone.Message += " " + extMsg
+		if len(clone.Message) == 0 {
+			clone.Message = extMsg
+		} else {
+			clone.Message += " " + extMsg
+		}
 	}
 
 	// handle error inheritance:

--- a/gerror/factory_test.go
+++ b/gerror/factory_test.go
@@ -1,0 +1,67 @@
+package gerror_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/drshriveer/gtools/gerror"
+)
+
+func TestCloneBase(t *testing.T) {
+	t.Parallel()
+	ErrNoMessage := gerror.FactoryOf(&gerror.GError{
+		Name:    "ErrBase",
+		Message: "",
+		Source:  "",
+	})
+
+	tests := []struct {
+		description string
+		input       gerror.Error
+
+		expectedName      string
+		expectedMessage   string
+		expectedSource    string
+		expectedDetailTag string
+	}{
+		{
+			description:     "add message does not include extra white space",
+			input:           ErrNoMessage.Msg("hi! blah"),
+			expectedName:    "ErrBase",
+			expectedSource:  "gerror_test:TestCloneBase",
+			expectedMessage: "hi! blah",
+		},
+		{
+			description:     "add message is trimmed",
+			input:           ErrNoMessage.Msg(" hi! blah "),
+			expectedName:    "ErrBase",
+			expectedSource:  "gerror_test:TestCloneBase",
+			expectedMessage: "hi! blah",
+		},
+		{
+			description:     "add message is trimmed + chaining",
+			input:           ErrNoMessage.Msg(" hi! blah ").(*gerror.GError).Msg(". bye! "),
+			expectedName:    "ErrBase",
+			expectedSource:  "gerror_test:TestCloneBase",
+			expectedMessage: "hi! blah. bye!",
+		},
+		{
+			description:     "lots of whitespace is trimmed",
+			input:           ErrNoMessage.Msg("     hi! blah  \n"),
+			expectedName:    "ErrBase",
+			expectedSource:  "gerror_test:TestCloneBase",
+			expectedMessage: "hi! blah",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, test.expectedName, test.input.ErrName())
+			assert.Equal(t, test.expectedMessage, test.input.ErrMessage())
+			assert.Equal(t, test.expectedSource, test.input.ErrSource())
+			assert.Equal(t, test.expectedDetailTag, test.input.ErrDetailTag())
+		})
+	}
+}

--- a/gerror/factory_test.go
+++ b/gerror/factory_test.go
@@ -41,10 +41,10 @@ func TestCloneBase(t *testing.T) {
 		},
 		{
 			description:     "add message is trimmed + chaining",
-			input:           ErrNoMessage.Msg(" hi! blah ").(*gerror.GError).Msg(". bye! "),
+			input:           ErrNoMessage.Msg(" hi! blah ").(*gerror.GError).Msg("   \t bye! "),
 			expectedName:    "ErrBase",
 			expectedSource:  "gerror_test:TestCloneBase",
-			expectedMessage: "hi! blah. bye!",
+			expectedMessage: "hi! blah bye!",
 		},
 		{
 			description:     "lots of whitespace is trimmed",


### PR DESCRIPTION
### Background

→ when cloning a message we always add a space separator but this is wrong. Only do it sometimes.

### Changes

- fix bug

### Testing

- added regression tests