### PR TITLE
add more interface helpers to gencommon

### DIFF
--- a/gencommon/defined_interfaces.go
+++ b/gencommon/defined_interfaces.go
@@ -1,0 +1,49 @@
+package gencommon
+
+import (
+	"errors"
+	"go/types"
+
+	"golang.org/x/tools/go/packages"
+)
+
+var (
+	// ErrorInterface defines the error interface as a type for comparison.
+	ErrorInterface *types.Interface
+
+	// ContextInterface defines the error interface as a type for comparison.
+	ContextInterface *types.Interface
+)
+
+func init() {
+	var err error
+	ContextInterface, err = FindIFaceDef("context", "Context")
+	if err != nil {
+		panic(err)
+	}
+	ErrorInterface, err = FindIFaceDef("builtin", "error")
+	if err != nil {
+		panic(err)
+	}
+}
+
+// FindIFaceDef finds an interface definition of the given package and type.
+// Which can be used in type matching.
+func FindIFaceDef(pkgName, typeName string) (*types.Interface, error) {
+	cfg := &packages.Config{
+		Mode: packages.NeedTypesInfo | packages.NeedTypes,
+	}
+	pkgs, err := packages.Load(cfg, pkgName)
+	if err != nil {
+		return nil, err
+	}
+	if len(pkgs) != 1 {
+		return nil, errors.New("did not find exactly one package for " + pkgName)
+	}
+	typeInfo := pkgs[0].Types.Scope().Lookup(typeName)
+	iFace, ok := typeInfo.Type().Underlying().(*types.Interface)
+	if !ok {
+		return nil, errors.New("type " + typeName + " was not an interface!")
+	}
+	return iFace, nil
+}

--- a/gencommon/defined_interfaces_test.go
+++ b/gencommon/defined_interfaces_test.go
@@ -1,0 +1,24 @@
+package gencommon
+
+import (
+	"go/types"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindIFaceDef(t *testing.T) {
+	validErrInterface := types.NewInterfaceType([]*types.Func{
+		types.NewFunc(
+			0,
+			nil,
+			"Error",
+			types.NewSignatureType(nil, nil, nil, nil,
+				types.NewTuple(types.NewVar(0, nil, "", types.Typ[types.String])),
+				false)),
+	}, nil)
+
+	iFace, err := FindIFaceDef("builtin", "error")
+	assert.NoError(t, err)
+	assert.True(t, types.Implements(iFace, validErrInterface))
+}

--- a/gencommon/interface.go
+++ b/gencommon/interface.go
@@ -7,17 +7,6 @@ import (
 	"golang.org/x/tools/go/packages"
 )
 
-// ErrorInterface defines the error interface as a type for comparison.
-var ErrorInterface = types.NewInterfaceType([]*types.Func{
-	types.NewFunc(
-		0,
-		nil,
-		"Error",
-		types.NewSignatureType(nil, nil, nil, nil,
-			types.NewTuple(types.NewVar(0, nil, "", types.Typ[types.String])),
-			false)),
-}, nil)
-
 // Interface is a parsed interface.
 type Interface struct {
 	// IsInterface returns false if the actual underlying object is a struct rather than an interface.

--- a/gencommon/interface.go
+++ b/gencommon/interface.go
@@ -18,6 +18,9 @@ type Interface struct {
 	// Name of the type (or interface).
 	Name string
 
+	// TypeRef is how to reference this interface outside of the current package.
+	TypeRef string
+
 	// List of methods!
 	Methods Methods
 }
@@ -99,6 +102,7 @@ func namedTypeToInterface(ih *ImportHandler, pkg *packages.Package, t *types.Nam
 	result := &Interface{
 		Name:        t.Obj().Name(),
 		IsInterface: false,
+		TypeRef:     ih.ExtractTypeRef(t),
 		Comments:    CommentsFromObj(pkg, t.Obj().Name()),
 		Methods:     make(Methods, 0, t.NumMethods()),
 	}

--- a/gencommon/interface.go
+++ b/gencommon/interface.go
@@ -188,9 +188,16 @@ func unwrapToHasMethods(t types.Type) (hasMethods, bool) {
 	if t == nil {
 		return nil, false
 	}
-	v, ok := t.(hasMethods)
-	if !ok || v.NumMethods() == 0 {
-		return unwrapToHasMethods(t.Underlying())
+
+	// so.. i know it is absolutely necessary to do one unwrap sometimes
+	// but why it looks infitiely other times I cannot say.
+	// I reallly wish go's tooling was better around all these types.
+	for i := 0; i < 5; i++ {
+		v, ok := t.(hasMethods)
+		if ok && v.NumMethods() > 0 {
+			return v, true
+		}
+		t = t.Underlying()
 	}
-	return v, true
+	return nil, false
 }

--- a/gencommon/method.go
+++ b/gencommon/method.go
@@ -59,6 +59,11 @@ func (m *Method) AcceptsContext() bool {
 	return types.Implements(first.actualType, ContextInterface)
 }
 
+// HasResults returns true if the method has results to return.
+func (m *Method) HasResults() bool {
+	return len(m.Output) > 0
+}
+
 func getName(names ...*ast.Ident) string {
 	for _, name := range names {
 		return name.Name

--- a/gencommon/method.go
+++ b/gencommon/method.go
@@ -47,7 +47,7 @@ func (m *Method) ReturnsError() bool {
 		return false
 	}
 	last := m.Output[len(m.Output)-1]
-	return types.Implements(last.actualType, ErrorInterface)
+	return TypeImplements(last.ActualType, ErrorInterface)
 }
 
 // AcceptsContext returns true if the first argument implements the context interface.
@@ -56,7 +56,7 @@ func (m *Method) AcceptsContext() bool {
 		return false
 	}
 	first := m.Input[0]
-	return types.Implements(first.actualType, ContextInterface)
+	return TypeImplements(first.ActualType, ContextInterface)
 }
 
 // HasResults returns true if the method has results to return.

--- a/gencommon/method.go
+++ b/gencommon/method.go
@@ -50,6 +50,15 @@ func (m *Method) ReturnsError() bool {
 	return types.Implements(last.actualType, ErrorInterface)
 }
 
+// AcceptsContext returns true if the first argument implements the context interface.
+func (m *Method) AcceptsContext() bool {
+	if len(m.Input) == 0 {
+		return false
+	}
+	first := m.Input[0]
+	return types.Implements(first.actualType, ContextInterface)
+}
+
 func getName(names ...*ast.Ident) string {
 	for _, name := range names {
 		return name.Name

--- a/gencommon/params.go
+++ b/gencommon/params.go
@@ -136,3 +136,12 @@ type Param struct {
 func (p Param) Declaration() string {
 	return p.Name + " " + p.TypeRef
 }
+
+// Implements returns true if the parameter implements the interface type provided.
+func (p Param) Implements(pkgName, typeName string) bool {
+	iFace, err := FindIFaceDef(pkgName, typeName)
+	if err != nil {
+		return false
+	}
+	return types.Implements(p.actualType, iFace)
+}

--- a/gencommon/params.go
+++ b/gencommon/params.go
@@ -33,7 +33,7 @@ func ParamsFromSignatureTuple(ih *ImportHandler, tuple *types.Tuple, variadic bo
 	for i := 0; i < tuple.Len(); i++ {
 		v := tuple.At(i)
 		p := &Param{
-			actualType: v.Type(),
+			ActualType: v.Type(),
 			TypeRef:    ih.ExtractTypeRef(v.Type()),
 			Name:       v.Name(),
 			Variadic:   tuple.Len() == i+1 && variadic,
@@ -114,7 +114,7 @@ func (ps Params) Declarations() string {
 func (ps Params) ensureNames() {
 	for i, p := range ps {
 		if len(p.Name) == 0 {
-			if len(ps)-1 == i && types.Implements(p.actualType, ErrorInterface) {
+			if len(ps)-1 == i && types.Implements(p.ActualType, ErrorInterface) {
 				p.Name = "err"
 			} else {
 				p.Name = "arg" + strconv.FormatInt(int64(i), 10)
@@ -125,7 +125,7 @@ func (ps Params) ensureNames() {
 
 // Param has information about a single parameter.
 type Param struct {
-	actualType types.Type
+	ActualType types.Type
 	TypeRef    string
 	Name       string
 	Comments   Comments
@@ -135,13 +135,4 @@ type Param struct {
 // Declaration returns a name and type.
 func (p Param) Declaration() string {
 	return p.Name + " " + p.TypeRef
-}
-
-// Implements returns true if the parameter implements the interface type provided.
-func (p Param) Implements(pkgName, typeName string) bool {
-	iFace, err := FindIFaceDef(pkgName, typeName)
-	if err != nil {
-		return false
-	}
-	return types.Implements(p.actualType, iFace)
 }

--- a/gencommon/paths.go
+++ b/gencommon/paths.go
@@ -3,6 +3,7 @@ package gencommon
 import (
 	"bytes"
 	"go/format"
+	"golang.org/x/tools/imports"
 	"log"
 	"os"
 	"path"
@@ -49,6 +50,12 @@ func Write(tmpl *template.Template, templateData any, destination string) error 
 	if err != nil {
 		log.Printf("[WARN] - formatting of source file failed with error: %+v", err)
 		result = buf.Bytes()
+	}
+
+	// process imports; format and add/remove if needed.
+	result, err = imports.Process("", result, nil)
+	if err != nil {
+		log.Printf("[WARN] - formatting imports of source file failed with error: %+v", err)
 	}
 
 	f, err := os.OpenFile(destination, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.ModePerm)

--- a/gencommon/paths.go
+++ b/gencommon/paths.go
@@ -3,12 +3,13 @@ package gencommon
 import (
 	"bytes"
 	"go/format"
-	"golang.org/x/tools/imports"
 	"log"
 	"os"
 	"path"
 	"strings"
 	"text/template"
+
+	"golang.org/x/tools/imports"
 )
 
 // SanitizeSourceFile ensures a valid source context.

--- a/gencommon/paths.go
+++ b/gencommon/paths.go
@@ -46,23 +46,24 @@ func Write(tmpl *template.Template, templateData any, destination string) error 
 	if err != nil {
 		return err
 	}
-
-	result, err := format.Source(buf.Bytes())
+	tempResult := buf.Bytes()
+	result, err := format.Source(tempResult)
+	if err == nil {
+		// process imports; format and add/remove if needed.
+		result, err = imports.Process("", result, nil)
+	}
 	if err != nil {
 		log.Printf("[WARN] - formatting of source file failed with error: %+v", err)
-		result = buf.Bytes()
-	}
-
-	// process imports; format and add/remove if needed.
-	result, err = imports.Process("", result, nil)
-	if err != nil {
-		log.Printf("[WARN] - formatting imports of source file failed with error: %+v", err)
+		// gracefully recover- the actual file is broken but it is helpful to see
+		// what is wrong with the output itself.
+		result = tempResult
 	}
 
 	f, err := os.OpenFile(destination, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.ModePerm)
 	if err != nil {
 		return err
 	}
+
 	defer f.Close()
 	_, err = f.WriteAt(result, 0)
 	return err

--- a/gerror/README.md
+++ b/gerror/README.md
@@ -1,6 +1,8 @@
 gError
 ======
 
+TL;DR Don't use this! This was an attempt at something cool that ultimately didn't work out. I haven't removed this just yet, because I still intend to borrow some bits of it in the future (and technically the base gerror is still used in code within this package). But just don't use it! :)
+
 gError is an opinionated error model for Go that takes a metric-first standpoint on errors.
 
 [Docs](https://pkg.go.dev/github.com/drshriveer/gtool/gerror)
@@ -32,7 +34,7 @@ Below are the tenants that lead to this library's development. Keeping them in m
 	-	Implement client interceptors to automatically convert errors into the correct type.
 	-	TODO: provide example.
 -	**Returned errors should be tested**
-	-	Raw string matching and error wrapping make testing errors brittle. Verify the error returned is the error you intended.
+	-	Raw string matching and error wrapping make testing errors brittle.
 -	**Errors must treat metrics as a first-class citizen**
 	-	That means errors need to be *Named* and have a concept of their *Source*.
 	-	Consider pairing gError with something like [gowrap](https://github.com/hexdigest/gowrap) to generate instrumented interfaces that emit metrics when an error is encountered.

--- a/gerror/internal/custom_error.gerror.go
+++ b/gerror/internal/custom_error.gerror.go
@@ -3,6 +3,7 @@ package internal
 
 import (
 	"fmt"
+
 	"github.com/drshriveer/gtools/gerror"
 )
 


### PR DESCRIPTION
### Background

→ We have a use case for knowing if a method accepts a context. This PR adds that function to Method and cleans up the way we extract interface references for the purpose of type matching. This also opens the door for more generalized parameter interface checking for which many utilities were included in this.

### Changes

- Extract interface references via packages; do not manually construct interfaces (e.g. like I did with error).
- Add `func (m *Method) AcceptsContext() bool {` method
- Add functions for extracting and comparing interfaces.
- few other fixes.

### Testing

- tested against stately genwrapper