### PR TITLE
ensure method param names

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -41,13 +41,62 @@ linters-settings:
       - loopclosure # we use GOEXPERIMENT := "loopvar"
   goimports:
     local-prefixes: github.com/drshriveer/gtools
-# if the stutter check in revive is annoying uncomment the following:
-#  revive:
-#    rules:
-#      - name: exported
-#        arguments:
-#          - disableStutteringCheck
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+    disabled-checks:
+      # ifElseChain forces a switch statement for any if/else block > 2 conditions dumb.
+      # Do what you want when you want.
+      - ifElseChain
+      # paramTypeCombine requires
+      # func(thing, thing string) over func(thing string, thing string)
+      # I don't care.
+      - paramTypeCombine
+      # filepathJoin wants path.Join(prefix,node,node)
+      # instead of path.Join(prefix, "node/node")
+      # I don't care..
+      - filepathJoin
+      # hugeParam is actually pretty interesting-
+      # it detects objects that are large and better to pass by
+      # pointer. I like this in theory, but it is noisy.
+      - hugeParam
+      # .. do we really have to name them all?
+      - unnamedResult
+  gosec:
+    excludes:
+      # G601 Implicit memory aliasing in for loop. should not be valid with loopvar experiment...
+      - G601
+  nakedret:
+    # No naked returns, ever.
+    max-func-lines: 1 # Default: 30
+
 issues:
   include:
-    - EXC0012  # EXC0012 revive: Annoying issue about not having a comment. The rare codebase has such comments
-    - EXC0014  # EXC0014 revive: Annoying issue about not having a comment. The rare codebase has such comments
+    - EXC0012  # I prefer to force comments.
+    - EXC0014  # I prefer to force comments.
+  exclude-rules:
+    # Ignore use of weak random number generators in tests
+    - path: _test\.go
+      text: "G404:"
+      linters:
+        - gosec
+
+    # go:generate directives must be on one line; no long-line linting here.
+    - linters:
+        - lll
+      source: "^//go:generate "
+
+    # I don't want to disable all of var-naming in revive, but I do want to permit
+    # the use of ctx_ as a var name for specific use cases.
+    - linters:
+        - revive
+      text: "var-naming: don't use leading k in Go names|var-naming: don't use underscores in Go names; method parameter ctx_ should be ctx|var-naming: don't use underscores in Go names; var err_ should be err"
+
+    # embedded generated 'unimplentedXXXServer's can be unused at times.
+    - linters:
+        - unused
+      source: "^\\s*unimplemented\\w*Server"

--- a/gencommon/method.go
+++ b/gencommon/method.go
@@ -68,8 +68,8 @@ func (m *Method) HasResults() bool {
 
 func (m *Method) ensureParamNames() {
 	paramDeduper := make(map[string]int, len(m.Input)+len(m.Output))
-	m.Input.ensureNames(false, paramDeduper)
-	m.Output.ensureNames(true, paramDeduper)
+	m.Input.ensureNames(paramDeduper, false)
+	m.Output.ensureNames(paramDeduper, true)
 }
 
 func getName(names ...*ast.Ident) string {

--- a/gencommon/method.go
+++ b/gencommon/method.go
@@ -67,8 +67,9 @@ func (m *Method) HasResults() bool {
 }
 
 func (m *Method) ensureParamNames() {
-	m.Input.ensureNames(false)
-	m.Output.ensureNames(true)
+	paramDeduper := make(map[string]int, len(m.Input)+len(m.Output))
+	m.Input.ensureNames(false, paramDeduper)
+	m.Output.ensureNames(true, paramDeduper)
 }
 
 func getName(names ...*ast.Ident) string {

--- a/gencommon/method.go
+++ b/gencommon/method.go
@@ -18,11 +18,13 @@ type Method struct {
 // MethodFromSignature returns a partially constructed Method-- it contains the raw function
 // info, nothing else.
 func MethodFromSignature(ih *ImportHandler, signature *types.Signature) *Method {
-	return &Method{
+	m := &Method{
 		Name:   "func", // default name
 		Input:  ParamsFromSignatureTuple(ih, signature.Params(), signature.Variadic()),
 		Output: ParamsFromSignatureTuple(ih, signature.Results(), false),
 	}
+	m.ensureParamNames()
+	return m
 }
 
 // Signature returns the full signature of the method.
@@ -62,6 +64,11 @@ func (m *Method) AcceptsContext() bool {
 // HasResults returns true if the method has results to return.
 func (m *Method) HasResults() bool {
 	return len(m.Output) > 0
+}
+
+func (m *Method) ensureParamNames() {
+	m.Input.ensureNames(false)
+	m.Output.ensureNames(true)
 }
 
 func getName(names ...*ast.Ident) string {

--- a/gencommon/params.go
+++ b/gencommon/params.go
@@ -112,15 +112,15 @@ func (ps Params) ensureNames(paramDeduper map[string]int, isOutput bool) {
 	// process the named variables first:
 	for _, p := range ps {
 		if p.Name != "" {
-			p.Name = getSafeParamName(paramDeduper, prefix, false)
+			p.Name = getSafeParamName(paramDeduper, p.Name, false)
 		}
 	}
 
 	for i, p := range ps {
 		if p.Name == "" {
-			if isOutput && len(ps)-1 == i && types.Implements(p.ActualType, ErrorInterface) {
+			if isOutput && len(ps)-1 == i && TypeImplements(p.ActualType, ErrorInterface) {
 				p.Name = getSafeParamName(paramDeduper, "err", false)
-			} else if !isOutput && i == 0 && types.Implements(p.ActualType, ContextInterface) {
+			} else if !isOutput && i == 0 && TypeImplements(p.ActualType, ContextInterface) {
 				p.Name = getSafeParamName(paramDeduper, "ctx", false)
 			} else {
 				p.Name = getSafeParamName(paramDeduper, prefix, true)

--- a/gencommon/params.go
+++ b/gencommon/params.go
@@ -71,7 +71,6 @@ func (ps Params) TypeNames() string {
 // ParamNames returns a comma-separated list of the parameter names.
 // e.g. arg1, arg2, arg3...
 func (ps Params) ParamNames() string {
-	ps.ensureNames()
 	result := strings.Builder{}
 	for i, p := range ps {
 		result.WriteString(p.Name)
@@ -85,17 +84,9 @@ func (ps Params) ParamNames() string {
 	return result.String()
 }
 
-// ParamNamesOmitLast returns a comma-separated list of the parameter names.
-// But will omit the last element; useful for custom error
-// e.g. arg1, arg2, arg3...
-func (ps Params) ParamNamesOmitLast() string {
-	return ps[:len(ps)-1].ParamNames()
-}
-
 // Declarations returns a comma-separated list of parameter name and type:
 // e.g. arg1 Type1, arg2 Type2 ...,.
 func (ps Params) Declarations() string {
-	ps.ensureNames()
 	result := strings.Builder{}
 	for i, p := range ps {
 		result.WriteString(p.Name)
@@ -111,13 +102,17 @@ func (ps Params) Declarations() string {
 	return result.String()
 }
 
-func (ps Params) ensureNames() {
+func (ps Params) ensureNames(isOutput bool) {
+	prefix := "arg"
+	if isOutput {
+		prefix = "ret"
+	}
 	for i, p := range ps {
 		if len(p.Name) == 0 {
-			if len(ps)-1 == i && types.Implements(p.ActualType, ErrorInterface) {
+			if isOutput && len(ps)-1 == i && types.Implements(p.ActualType, ErrorInterface) {
 				p.Name = "err"
 			} else {
-				p.Name = "arg" + strconv.FormatInt(int64(i), 10)
+				p.Name = prefix + strconv.FormatInt(int64(i), 10)
 			}
 		}
 	}

--- a/gencommon/params.go
+++ b/gencommon/params.go
@@ -102,8 +102,8 @@ func (ps Params) Declarations() string {
 	return result.String()
 }
 
-func (ps Params) ensureNames(isOutput bool, paramDeduper map[string]int) {
-	// prefix == the unnamed parameter prefix to use.
+func (ps Params) ensureNames(paramDeduper map[string]int, isOutput bool) {
+	// paramName == the unnamed parameter paramName to use.
 	prefix := "arg"
 	if isOutput {
 		prefix = "ret"
@@ -143,15 +143,18 @@ func (p Param) Declaration() string {
 	return p.Name + " " + p.TypeRef
 }
 
-func getSafeParamName(prefixCounter map[string]int, prefix string, alwaysNumber bool) string {
-	v, ok := prefixCounter[prefix]
-	result := prefix
+// getSafeParamName returns a "safe" param name.
+// note: I'm pretty sure this is technically only safe when the already defined params
+// are processed first which is exactly what ensureNames does.
+func getSafeParamName(paramDeduper map[string]int, paramName string, alwaysNumber bool) string {
+	v, ok := paramDeduper[paramName]
+	result := paramName
 	if ok || alwaysNumber {
 		result += strconv.FormatInt(int64(v), 10)
 		v++
 	}
-	// else don't modify the intended prefix.
-	// ensure the prefix is in the map:
-	prefixCounter[prefix] = v
+	// else don't modify the intended paramName.
+	// ensure the paramName is in the map:
+	paramDeduper[paramName] = v
 	return result
 }

--- a/gencommon/params_test.go
+++ b/gencommon/params_test.go
@@ -1,0 +1,37 @@
+package gencommon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_getSafeParamName(t *testing.T) {
+	prefixCounter := map[string]int{}
+	tests := []struct {
+		prefix       string
+		alwaysNumber bool
+		expected     string
+	}{
+		{prefix: "ret", alwaysNumber: true, expected: "ret0"},
+		{prefix: "ret", alwaysNumber: true, expected: "ret1"},
+		{prefix: "ret", alwaysNumber: true, expected: "ret2"},
+		{prefix: "ret", alwaysNumber: false, expected: "ret3"},
+		{prefix: "ret1", alwaysNumber: false, expected: "ret1"},
+
+		{prefix: "arg", alwaysNumber: false, expected: "arg"},
+		{prefix: "arg", alwaysNumber: true, expected: "arg0"},
+		{prefix: "arg", alwaysNumber: true, expected: "arg1"},
+		{prefix: "arg", alwaysNumber: true, expected: "arg2"},
+
+		{prefix: "someArg", alwaysNumber: false, expected: "someArg"},
+		{prefix: "somethingelse", alwaysNumber: false, expected: "somethingelse"},
+	}
+
+	for _, test := range tests {
+		t.Run("expected "+test.expected, func(t *testing.T) {
+			result := getSafeParamName(prefixCounter, test.prefix, test.alwaysNumber)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}

--- a/gencommon/params_test.go
+++ b/gencommon/params_test.go
@@ -9,28 +9,28 @@ import (
 func Test_getSafeParamName(t *testing.T) {
 	prefixCounter := map[string]int{}
 	tests := []struct {
-		prefix       string
+		paramName    string
 		alwaysNumber bool
 		expected     string
 	}{
-		{prefix: "ret", alwaysNumber: true, expected: "ret0"},
-		{prefix: "ret", alwaysNumber: true, expected: "ret1"},
-		{prefix: "ret", alwaysNumber: true, expected: "ret2"},
-		{prefix: "ret", alwaysNumber: false, expected: "ret3"},
-		{prefix: "ret1", alwaysNumber: false, expected: "ret1"},
+		{paramName: "ret", alwaysNumber: true, expected: "ret0"},
+		{paramName: "ret", alwaysNumber: true, expected: "ret1"},
+		{paramName: "ret", alwaysNumber: true, expected: "ret2"},
+		{paramName: "ret", alwaysNumber: false, expected: "ret3"},
+		{paramName: "ret1", alwaysNumber: false, expected: "ret1"},
 
-		{prefix: "arg", alwaysNumber: false, expected: "arg"},
-		{prefix: "arg", alwaysNumber: true, expected: "arg0"},
-		{prefix: "arg", alwaysNumber: true, expected: "arg1"},
-		{prefix: "arg", alwaysNumber: true, expected: "arg2"},
+		{paramName: "arg", alwaysNumber: false, expected: "arg"},
+		{paramName: "arg", alwaysNumber: true, expected: "arg0"},
+		{paramName: "arg", alwaysNumber: true, expected: "arg1"},
+		{paramName: "arg", alwaysNumber: true, expected: "arg2"},
 
-		{prefix: "someArg", alwaysNumber: false, expected: "someArg"},
-		{prefix: "somethingelse", alwaysNumber: false, expected: "somethingelse"},
+		{paramName: "someArg", alwaysNumber: false, expected: "someArg"},
+		{paramName: "somethingelse", alwaysNumber: false, expected: "somethingelse"},
 	}
 
 	for _, test := range tests {
 		t.Run("expected "+test.expected, func(t *testing.T) {
-			result := getSafeParamName(prefixCounter, test.prefix, test.alwaysNumber)
+			result := getSafeParamName(prefixCounter, test.paramName, test.alwaysNumber)
 			assert.Equal(t, test.expected, result)
 		})
 	}

--- a/gencommon/paths.go
+++ b/gencommon/paths.go
@@ -15,7 +15,7 @@ import (
 // SanitizeSourceFile ensures a valid source context.
 func SanitizeSourceFile(srcFile string) string {
 	pwd := os.Getenv("PWD")
-	if len(srcFile) == 0 {
+	if srcFile == "" {
 		log.Fatal("this command should be run in a go:generate context or with the correct source file flag set.")
 	}
 
@@ -29,7 +29,7 @@ func SanitizeSourceFile(srcFile string) string {
 // This should be run AFTER SanitizeSourceFile, using the result of it as the srcFile argument.
 func SanitizeOutFile(flagVal, srcFile, genName string) string {
 	srcFileDir, srcFileName := path.Split(srcFile)
-	if len(flagVal) == 0 {
+	if flagVal == "" {
 		return path.Join(srcFileDir, strings.TrimSuffix(srcFileName, ".go")+"."+genName+".go")
 	}
 	if !path.IsAbs(flagVal) {

--- a/gerror/factory.go
+++ b/gerror/factory.go
@@ -108,13 +108,13 @@ func CloneBase[T factoryOf](
 	}
 
 	// handle source:
-	if len(source) > 0 && len(clone.Source) == 0 {
+	if len(source) > 0 && clone.Source == "" {
 		clone.Source = source
 	}
 
 	// handle detail tags:
 	if len(dTag) > 0 {
-		if len(clone.detailTag) == 0 {
+		if clone.detailTag == "" {
 			clone.detailTag = dTag
 		} else {
 			clone.detailTag += "-" + dTag
@@ -124,7 +124,7 @@ func CloneBase[T factoryOf](
 	// handle message extension:
 	extMsg = strings.TrimSpace(extMsg)
 	if len(extMsg) > 0 {
-		if len(clone.Message) == 0 {
+		if clone.Message == "" {
 			clone.Message = extMsg
 		} else {
 			clone.Message += " " + extMsg
@@ -149,7 +149,7 @@ func CloneBase[T factoryOf](
 	}
 
 	clone.stack = makeStack(stackType, defaultSkip)
-	if len(clone.Source) == 0 {
+	if clone.Source == "" {
 		clone.Source = clone.stack.NearestExternal().Metric()
 		if stackType == SourceStack {
 			clone.stack = nil

--- a/gerror/internal/err_with_custom_convert.go
+++ b/gerror/internal/err_with_custom_convert.go
@@ -10,7 +10,7 @@ import (
 
 // ErrWithCustomConvert is just a test.
 //
-//nolint:errname
+//nolint:errname // dumb
 type ErrWithCustomConvert struct {
 	gerror.GError
 	Property Status `gerror:"_,print,clone"`

--- a/gerror/stack.go
+++ b/gerror/stack.go
@@ -135,7 +135,6 @@ outer:
 			if curr == theRest[j] {
 				// only use everything before the repeat.
 				theRest = theRest[:i]
-				// theRest = theRest[:i-1]
 				break outer
 			}
 		}


### PR DESCRIPTION
### Background

→ I ran into two issues with method parameter names:
1. names between input and outputs will conflict if not already named. 
2. we do not ensure that fields are named prior to operations may change the size of a parameter list we operate on, and thus cause even the same parameter list to contain conflicting names.

### Changes

- always pre-populate method parameter names. 
- method returns variables if undefined are prefixed 'ret', inputs are prefixed 'arg'
- use of map to ensure no conflicts.
- attempt to use name 'ctx' for first argument in a function that implements Context.
- attempt to use name 'err' for last argument in function response that implements Error.


### Testing

- added minimal testing; this will be verified against stately in tests I cannot codify here.