### PR TITLE
gencommon: ExtractRefType support for maps of non-primitives

### DIFF
--- a/gencommon/imports.go
+++ b/gencommon/imports.go
@@ -73,7 +73,11 @@ func (ih *ImportHandler) ExtractTypeRef(typ types.Type) string {
 		// recurse to register relevant method imports-> then we only need the signature.
 		m := MethodFromSignature(ih, t)
 		return m.Signature()
-
+	case *types.Map:
+		// recurse to register types.
+		key := ih.ExtractTypeRef(t.Key())
+		value := ih.ExtractTypeRef(t.Elem())
+		return "map[" + key + "]" + value
 	case *types.Named:
 		pkg := t.Obj().Pkg()
 		typeName := t.Obj().Name()


### PR DESCRIPTION
### Background

→ ExtractTypeRef did not fully support maps; it only handled maps with primitives (by a default case).

```go
ReturnAMapOfTypes() map[types.KeyType]types.AttributeValue
```

would generate as:
```go
func (d *instrumentedService) ReturnAMapOfTypes() map[github.com/aws/aws-sdk-go-v2/service/dynamodb/types.KeyType]github.com/aws/aws-sdk-go-v2/service/dynamodb/types.AttributeValue {
```

### Changes

- add the map support

### Testing

- tested with stately 