### PR TITLE
add grpc and vt proto capabilities to gogenproto

### DIFF
--- a/gogenproto/README.md
+++ b/gogenproto/README.md
@@ -1,0 +1,80 @@
+gogenproto
+==========
+
+Is a generator that will generate go files from proto in a directory via a directive.
+
+### Getting Started
+
+**Dependencies:**
+
+This repo does not include any proto dependencies intentionally, because you should be in control of your own versions. Including any here would be a rather cumbersome bottleneck and a very strong reason not to use this repo. Therefore, you must bring your own versions of (i.e. they must be discoverable in PATH):
+
+-	`protoc`
+	-	hint mac: `brew install protobuf`
+-	`protoc-gen-go`
+	-	we recommend using a tools.go file to track and install versions of this.
+-	`protoc-gen-go-grpc` (if required)
+-	`protoc-gen-go-vtproto` (if required)
+
+**Install gogenproto:**
+
+```bash
+go install github.com/drshriveer/gtool/gogenproto/cmd/gogenproto@latest
+```
+
+##### Usage:
+
+In your working directory...
+
+**Define a proto file:**
+
+`./base/pkg/models/message.proto`
+
+```protobuf
+syntax = "proto3";
+
+package base.pkg.models;
+
+option go_package = "models/";
+
+message Message {
+  uint64 id = 1;
+  string content = 2;
+}
+```
+
+**Add the generate directive:**
+
+`./base/pkg/models/generate.go`
+
+```go
+package models
+
+//go:generate gogenproto -vt-proto
+```
+
+##### Options
+
+```bash
+ → ./path/to/bin/gogenproto --help
+Usage of ./bin/gogenproto:
+  -grpc
+        also generate grpc service definitions (experimental)
+  -input-dir string
+        path to root directory for proto generation (env PWD)
+  -inputDir string
+        path to root directory for proto generation (env PWD)
+  -output-dir string
+        relative output path for generated files (default "../")
+  -outputDir string
+        relative output path for generated files (default "../")
+  -recurse
+        generate protos recursively
+  -vt-proto
+        also generate vtproto (experimental)
+
+```
+
+### TODO:
+
+-	add support for proto validation

--- a/gogenproto/gen/generate.go
+++ b/gogenproto/gen/generate.go
@@ -20,6 +20,9 @@ type Generate struct {
 	OutputDir string `aliases:"outputDir" default:"../" usage:"relative output path for generated files"`
 
 	Recurse bool `default:"false" usage:"generate protos recursively"`
+	VTProto bool `default:"false" usage:"also generate vtproto (experimental)"`
+	GRPC    bool `default:"false" usage:"also generate grpc service definitions (experimental)"`
+
 	// TODO: other flags, like VTProto, GRPC, TS, etc,
 }
 
@@ -33,6 +36,18 @@ func (g Generate) Run() error {
 		"--proto_path=" + path.Dir(g.InputDir),
 		"--go_out=" + g.OutputDir,
 		"--fatal_warnings",
+	}
+	if g.VTProto {
+		args = append(args,
+			"--go-vtproto_out="+g.OutputDir,
+			"--go-vtproto_opt=paths=source_relative,features=marshal+unmarshal+size+equal+clone+pool",
+		)
+	}
+	if g.GRPC {
+		args = append(args,
+			"--go-grpc_out="+g.OutputDir,
+			"--go-grpc_opt=paths=source_relative",
+		)
 	}
 	args = append(args, paths...)
 	cmd := exec.Command("protoc", args...)


### PR DESCRIPTION
### Background

→ Adding some capabilities to gogenproto; flags to generate grpc and vt-proto definitions

### Changes

- add flags and related
- add readme

### Testing

- actually haven't tested this... these are marked experimental... will verify in stately.