### PR TITLE
Gs/gogenproto with include paths

### DIFF
--- a/gogenproto/README.md
+++ b/gogenproto/README.md
@@ -79,4 +79,4 @@ Usage of ./bin/gogenproto:
 ### TODO:
 
 -	add (native!) support for proto validation
--   add flags for other languages
+-	add flags for other languages

--- a/gogenproto/README.md
+++ b/gogenproto/README.md
@@ -56,10 +56,12 @@ package models
 ##### Options
 
 ```bash
- → ./path/to/bin/gogenproto --help
+→ ./path/to/bin/gogenproto --help
 Usage of ./bin/gogenproto:
   -grpc
         also generate grpc service definitions (experimental)
+  -include value
+        comma-separated paths to additional packages to include
   -input-dir string
         path to root directory for proto generation (env PWD)
   -inputDir string
@@ -71,10 +73,10 @@ Usage of ./bin/gogenproto:
   -recurse
         generate protos recursively
   -vt-proto
-        also generate vtproto (experimental)
-
+        also generate vtproto
 ```
 
 ### TODO:
 
--	add support for proto validation
+-	add (native!) support for proto validation
+-   add flags for other languages

--- a/gogenproto/gen/generate.go
+++ b/gogenproto/gen/generate.go
@@ -19,11 +19,12 @@ type Generate struct {
 	InputDir  string `aliases:"inputDir" env:"PWD" usage:"path to root directory for proto generation"`
 	OutputDir string `aliases:"outputDir" default:"../" usage:"relative output path for generated files"`
 
-	Recurse bool `default:"false" usage:"generate protos recursively"`
-	VTProto bool `default:"false" usage:"also generate vtproto (experimental)"`
-	GRPC    bool `default:"false" usage:"also generate grpc service definitions (experimental)"`
+	Recurse bool     `default:"false" usage:"generate protos recursively"`
+	VTProto bool     `default:"false" usage:"also generate vtproto"`
+	GRPC    bool     `default:"false" usage:"also generate grpc service definitions (experimental)"`
+	Include []string `usage:"comma-separated paths to additional packages to include"`
 
-	// TODO: other flags, like VTProto, GRPC, TS, etc,
+	// TODO: add flags for other languages, TS, etc,
 }
 
 // Run runs the generate command.
@@ -48,6 +49,9 @@ func (g Generate) Run() error {
 			"--go-grpc_out="+g.OutputDir,
 			"--go-grpc_opt=paths=source_relative",
 		)
+	}
+	for _, include := range g.Include {
+		args = append(args, "-I="+filepath.Join(g.InputDir, include))
 	}
 	args = append(args, paths...)
 	cmd := exec.Command("protoc", args...)

--- a/gogenproto/gen/generate.go
+++ b/gogenproto/gen/generate.go
@@ -24,7 +24,8 @@ type Generate struct {
 	GRPC    bool     `default:"false" usage:"also generate grpc service definitions (experimental)"`
 	Include []string `usage:"comma-separated paths to additional packages to include"`
 
-	// TODO: add flags for other languages, TS, etc,
+	// TODO: add flags for other languages, TS, etc.
+	// TODO: add NATIVE validation support.
 }
 
 // Run runs the generate command.


### PR DESCRIPTION
### Background

→ gogenproto has include paths; this helps enable support for things like buf validation. 

### Changes

- allow -include flag

### Testing

- validated in stately 