### PR TITLE
[gogenproto] Allow specifying a Go package mapping for import paths

### DIFF
--- a/gogenproto/README.md
+++ b/gogenproto/README.md
@@ -59,21 +59,17 @@ package models
 → ./path/to/bin/gogenproto --help
 Usage of ./bin/gogenproto:
   -grpc
-        also generate grpc service definitions (experimental)
+    	also generate grpc service definitions (experimental)
   -include value
-        comma-separated paths to additional packages to include
+    	comma-separated paths to additional directories to add to the proto include path. You can set an optional Go package mapping by appending a = and the package path, e.g. foo=github.com/foo/bar
   -input-dir string
-        path to root directory for proto generation (env PWD)
+    	path to root directory for proto generation (env PWD)
   -inputDir string
-        path to root directory for proto generation (env PWD)
-  -output-dir string
-        relative output path for generated files (default "../")
-  -outputDir string
-        relative output path for generated files (default "../")
+    	path to root directory for proto generation (env PWD)
   -recurse
-        generate protos recursively
+    	generate protos recursively
   -vt-proto
-        also generate vtproto
+    	also generate vtproto
 ```
 
 ### TODO:


### PR DESCRIPTION
### Background

→ It may be the case that you're importing protos that are generated in some other way than with `gogenproto` but which similarly have a conventional Go path mapping (e.g. they don't specify `go_package` but instead get automatic package names. Unfortunately right now that means you can't depend on these protos from your `gogenproto`-using protos, since you can't tell `gogenproto` what their package name will be.

### Changes

- Add an optional Go package prefix mapping to import paths. By appending `=` and the Go package prefix, you can use conventional (directory based) path mapping.

### Testing

- Tested in stately monorepo