### PR TITLE
update go version

### DIFF
--- a/gconfig/go.mod
+++ b/gconfig/go.mod
@@ -1,6 +1,6 @@
 module github.com/drshriveer/gtools/gconfig
 
-go 1.21.1
+go 1.23
 
 require (
 	github.com/drshriveer/gtools/genum v0.0.0-20240314202711-64624fbcb20a

--- a/gencommon/go.mod
+++ b/gencommon/go.mod
@@ -1,6 +1,6 @@
 module github.com/drshriveer/gtools/gencommon
 
-go 1.21.1
+go 1.23
 
 require (
 	github.com/drshriveer/gtools/set v0.0.0

--- a/genum/go.mod
+++ b/genum/go.mod
@@ -1,6 +1,6 @@
 module github.com/drshriveer/gtools/genum
 
-go 1.21.1
+go 1.23
 
 require (
 	github.com/drshriveer/gtools/gencommon v0.0.0-20240314202711-64624fbcb20a

--- a/gerror/error_test.go
+++ b/gerror/error_test.go
@@ -143,7 +143,7 @@ func TestStackSource(t *testing.T) {
 			// Looks Like: <PKG>.glob..func1
 			description: "pkg var > anonymous",
 			err:         pkgVarInlineFunc1,
-			expected:    "gerror_test:glob",
+			expected:    "gerror_test:init",
 		},
 		{
 			// Looks Like: github.com/drshriveer/gtools/gerror_test.TestStackSource.pkgFuncInlineErr1.func4

--- a/gerror/go.mod
+++ b/gerror/go.mod
@@ -1,6 +1,6 @@
 module github.com/drshriveer/gtools/gerror
 
-go 1.21.1
+go 1.23
 
 require (
 	github.com/drshriveer/gtools/gencommon v0.0.0-20240314202711-64624fbcb20a

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.21.1
+go 1.23
 
 use (
 	./gconfig

--- a/gogenproto/go.mod
+++ b/gogenproto/go.mod
@@ -1,6 +1,6 @@
 module github.com/drshriveer/gtools/gogenproto
 
-go 1.21.1
+go 1.23
 
 require (
 	github.com/drshriveer/gtools/gencommon v0.0.0-20240314202711-64624fbcb20a

--- a/gogenproto/internal/go.mod
+++ b/gogenproto/internal/go.mod
@@ -1,8 +1,6 @@
 module github.com/drshriveer/gtools/gogenproto/internal
 
-go 1.21.1
-
-toolchain go1.21.4
+go 1.23
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/gsort/go.mod
+++ b/gsort/go.mod
@@ -1,6 +1,6 @@
 module github.com/drshriveer/gtools/gsort
 
-go 1.21.1
+go 1.23
 
 require (
 	github.com/drshriveer/gtools/gencommon v0.0.0-20240314202711-64624fbcb20a

--- a/gsync/go.mod
+++ b/gsync/go.mod
@@ -1,6 +1,6 @@
 module github.com/drshriveer/gtools/gsync
 
-go 1.21.1
+go 1.23
 
 require (
 	github.com/drshriveer/gtools/gerror v0.0.0

--- a/log/go.mod
+++ b/log/go.mod
@@ -1,6 +1,6 @@
 module github.com/drshriveer/gtools/log
 
-go 1.21.1
+go 1.23
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/rutils/go.mod
+++ b/rutils/go.mod
@@ -1,3 +1,3 @@
 module github.com/drshriveer/gtools/rutils
 
-go 1.21.1
+go 1.23

--- a/set/go.mod
+++ b/set/go.mod
@@ -1,6 +1,6 @@
 module github.com/drshriveer/gtools/set
 
-go 1.21.1
+go 1.23
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/drshriveer/gtools/tools
 
-go 1.21.1
+go 1.23
 
 require github.com/moorereason/mdfmt v0.0.0-20181128042805-29e3d55cbe5a
 


### PR DESCRIPTION
### Background

last release failed: 

golang.org/x/tools@v0.28.0 requires go >= 1.22.0 (running go 1.21.1)

### Changes

- update go to 1.23
