### PR TITLE
gconfig allow defaults in environment variables

### DIFF
--- a/gconfig/README.md
+++ b/gconfig/README.md
@@ -25,6 +25,7 @@ go get -u github.com/drshriveer/gtools/gconfig
 	-	**Env Parsing:** The configuration library will automatically parse dimensions environment variables.
 	-	**GetDimension:** Extract a Dimension value via `gconfig.GetDimension[my.DimensionType](cfg)`.
 -	**Template Environmental Variables:** You can reference environmental variables in a config.yaml as values themselves! e.g. `var: ${{env: MY_ENV_VAR}}` will look up the variable `MY_ENV_VAR`.
+  - Defaults to use when an environmental variable is missing using the syntax `{{ env:MY_ENV_VAR | default_value }}`.
 -	**Environmental Overrides:** (TODO) In some cases it is useful to override a single static configuration variable in a specific environment. This can be done though the use of environmental variables.
 
 ### Usage

--- a/gconfig/README.md
+++ b/gconfig/README.md
@@ -25,7 +25,8 @@ go get -u github.com/drshriveer/gtools/gconfig
 	-	**Env Parsing:** The configuration library will automatically parse dimensions environment variables.
 	-	**GetDimension:** Extract a Dimension value via `gconfig.GetDimension[my.DimensionType](cfg)`.
 -	**Template Environmental Variables:** You can reference environmental variables in a config.yaml as values themselves! e.g. `var: ${{env: MY_ENV_VAR}}` will look up the variable `MY_ENV_VAR`.
-  - Defaults to use when an environmental variable is missing using the syntax `{{ env:MY_ENV_VAR | default_value }}`.
+	-	Defaults to use when an environmental variable is missing using the syntax `{{ env:MY_ENV_VAR | default_value }}`.
+	-	Note: any `"` characters will be trimmed from default values... e.g. `{{ env:MY_ENV_VAR | "" }}` would default to an empty string.
 -	**Environmental Overrides:** (TODO) In some cases it is useful to override a single static configuration variable in a specific environment. This can be done though the use of environmental variables.
 
 ### Usage

--- a/gconfig/yaml_templates.go
+++ b/gconfig/yaml_templates.go
@@ -3,6 +3,7 @@ package gconfig
 import (
 	"os"
 	"regexp"
+	"strings"
 )
 
 type templateVariable interface {
@@ -28,7 +29,8 @@ func (envVarTmpl) MatchAndResolve(in string) (out string, ok bool, err error) {
 	if !ok {
 		// This is the "default" case, where the environment variable is not found.
 		if len(matches) == 3 && matches[2] != "" {
-			return matches[2], true, nil
+			out = strings.Trim(matches[2], `"`)
+			return out, true, nil
 		}
 
 		return out, false, ErrFailedParsing.Msg(

--- a/gconfig/yaml_templates.go
+++ b/gconfig/yaml_templates.go
@@ -15,7 +15,7 @@ var templates = []templateVariable{
 
 type envVarTmpl struct{}
 
-var envVarTmplMatcher = regexp.MustCompile(`^\$\{\{\s*env:\s*(\w+)\s*\}\}$`)
+var envVarTmplMatcher = regexp.MustCompile(`^\$\{\{\s*env:\s*(\w+)\s*\|?\s*(.*\S)?\s*\}\}$`)
 
 func (envVarTmpl) MatchAndResolve(in string) (out string, ok bool, err error) {
 	out = in
@@ -26,6 +26,11 @@ func (envVarTmpl) MatchAndResolve(in string) (out string, ok bool, err error) {
 	envVarName := matches[1]
 	out, ok = os.LookupEnv(envVarName)
 	if !ok {
+		// This is the "default" case, where the environment variable is not found.
+		if len(matches) == 3 && matches[2] != "" {
+			return matches[2], true, nil
+		}
+
 		return out, false, ErrFailedParsing.Msg(
 			"templated environment environment variable %s not found in env",
 			envVarName)

--- a/gconfig/yaml_templates_test.go
+++ b/gconfig/yaml_templates_test.go
@@ -31,6 +31,12 @@ func TestEnvVarTmpl_MatchAndResolve(t *testing.T) {
 			expectedError:  ErrFailedParsing,
 		},
 		{
+			description:    "template found, env var not found, default provided",
+			input:          "${{env:MY_ENV_VAR|some-default}}",
+			expectedOutput: "some-default",
+			expectedUsed:   true,
+		},
+		{
 			description:    "template found, env var used",
 			input:          "${{env:MY_ENV_VAR}}",
 			envVal:         "aws:secret",
@@ -57,6 +63,12 @@ func TestEnvVarTmpl_MatchAndResolve(t *testing.T) {
 			envVal:         "aws:secret",
 			expectedUsed:   true,
 			expectedOutput: "aws:secret",
+		},
+		{
+			description:    "template found, env var not found, default provided with spacing",
+			input:          "${{  env:MY_ENV_VAR  |  some-default  }}",
+			expectedOutput: "some-default",
+			expectedUsed:   true,
 		},
 	}
 

--- a/gconfig/yaml_templates_test.go
+++ b/gconfig/yaml_templates_test.go
@@ -37,6 +37,18 @@ func TestEnvVarTmpl_MatchAndResolve(t *testing.T) {
 			expectedUsed:   true,
 		},
 		{
+			description:    "template found, env var not found, empty string default",
+			input:          `${{env:MY_ENV_VAR|""}}`,
+			expectedOutput: "",
+			expectedUsed:   true,
+		},
+		{
+			description:    "template found, env var not found, empty string default",
+			input:          `${{env:MY_ENV_VAR|""}}`,
+			expectedOutput: "",
+			expectedUsed:   true,
+		},
+		{
 			description:    "template found, env var used",
 			input:          "${{env:MY_ENV_VAR}}",
 			envVal:         "aws:secret",


### PR DESCRIPTION
### Background

→ want to be able to supply a default (i.e. not error)

### Changes

- allow default value parsing

### Testing

- added minimal testing