### PR TITLE
gogencommon: fix duplicate pkg import bug

### DIFF
--- a/gencommon/imports.go
+++ b/gencommon/imports.go
@@ -154,7 +154,7 @@ func (ih *ImportHandler) addNamed(t named) string {
 func (ih *ImportHandler) addImportDescSafe(i *ImportDesc, numberedAlias int) *ImportDesc {
 	currentAlias := i.Alias
 	if numberedAlias > 0 {
-		currentAlias = currentAlias + strconv.FormatInt(int64(numberedAlias), 10)
+		currentAlias += strconv.FormatInt(int64(numberedAlias), 10)
 	}
 	for _, existing := range ih.imports {
 		if existing.Alias == currentAlias {

--- a/gencommon/interface_test.go
+++ b/gencommon/interface_test.go
@@ -40,6 +40,7 @@ func TestFindInterface(t *testing.T) {
 				"CMethod",
 				"DMethod",
 				"MethodTakesAlias",
+				"MethodWithParamsFromPackagesWithSameName",
 			},
 		},
 		{
@@ -56,6 +57,7 @@ func TestFindInterface(t *testing.T) {
 				"DMethod",
 				"bPrivate",
 				"MethodTakesAlias",
+				"MethodWithParamsFromPackagesWithSameName",
 			},
 		},
 	}
@@ -77,13 +79,15 @@ func TestFindInterface(t *testing.T) {
 			for _, m := range iface.Methods {
 				assert.Truef(t, expected.Remove(m.Name), "found duplicate OR unexpected method %q", m.Name)
 				// check that CMethod has a comment:
-				if m.Name == "CMethod" {
+				switch m.Name {
+				case "CMethod":
 					assert.NotEmpty(t, m.Comments)
-				}
-				if m.Name == "MethodTakesAlias" {
+				case "MethodTakesAlias":
 					assert.Equal(t,
 						"arg0 AliasID, arg1 v2.InputTypeAtV2, arg2 anyotherpackagename.InputTypeAtNonConsistentPackageName",
 						m.Input.Declarations())
+				case "MethodWithParamsFromPackagesWithSameName":
+					assert.Equal(t, "arg0 dupepkg.InputTypeAtV4, arg1 dupepkg1.InputTypeAtV5", m.Input.Declarations())
 				}
 			}
 			assert.Emptyf(t, expected.Slice(), "methods that were not found!")

--- a/gencommon/internal/nestedpkg/test_types.go
+++ b/gencommon/internal/nestedpkg/test_types.go
@@ -1,10 +1,20 @@
 //nolint:all // this is a test file
 package nestedpkg
 
+import (
+	v4dupepkg "github.com/drshriveer/gtools/gencommon/internal/nestedpkg/v4"
+	v5dupepkg "github.com/drshriveer/gtools/gencommon/internal/nestedpkg/v5"
+)
+
 type EmbeddedC struct{}
 
 func (e *EmbeddedC) FooMethod() {}
 func (e *EmbeddedC) BazMethod() {}
+func (c *EmbeddedC) MethodWithParamsFromPackagesWithSameName(
+	_ v4dupepkg.InputTypeAtV4,
+	_ v5dupepkg.InputTypeAtV5,
+) {
+}
 
 // CMethod is a method with a comment, the rare and only method with a comment.
 func (e *EmbeddedC) CMethod() {}

--- a/gencommon/internal/nestedpkg/v4/test_types.go
+++ b/gencommon/internal/nestedpkg/v4/test_types.go
@@ -1,0 +1,6 @@
+//nolint:all // this is a test file
+package dupepkg
+
+type InputTypeAtV4 struct {
+	Name string
+}

--- a/gencommon/internal/nestedpkg/v5/test_types.go
+++ b/gencommon/internal/nestedpkg/v5/test_types.go
@@ -1,0 +1,6 @@
+//nolint:all // this is a test file
+package dupepkg
+
+type InputTypeAtV5 struct {
+	Name string
+}


### PR DESCRIPTION
### Background

→ There is currently no handling for duplicate package imports when those package imports come from dependency files. This PR fixes it by deduplicating/assigning import aliases when a duplicate is found.

### Changes

- when adding import aliases detect duplicates and generate numbered aliases on the fly.

### Testing

- updated for this case