### PR TITLE
round 2 ensure recursive

### DIFF
--- a/gomonorepo/app_options.go
+++ b/gomonorepo/app_options.go
@@ -22,7 +22,7 @@ var (
 type AppOptions struct {
 	Root                      flags.Filename `long:"root" short:"r" description:"Root directory of the mono repo." default:"."`
 	InvocationDir             flags.Filename `long:"invocationDir" description:"If invocationDir is not the root directory, invocation will be limited to the invocationDir and its subdirectories."`
-	InvocationDirNotRecursive bool           `long:"non-recursive-from-invocation-dir" description:"When using invocationDir, turn off recursive invocation; limit to the invocation directory only."`
+	NonRecursiveInvocationDir bool           `long:"non-recursive-from-invocation-dir" description:"When using invocationDir, turn off recursive invocation; limit to the invocation directory only."`
 	Verbose                   bool           `long:"verbose" short:"v" description:"Enable verbose logging."`
 	Parallelism               int            `long:"parallelism" short:"p" description:"Permitted parallelism for tasks that can be parallelized." default:"4"`
 	Timeout                   time.Duration  `long:"timeout" short:"t" description:"Timeout for the command." default:"5m"`
@@ -64,7 +64,8 @@ func (x *AppOptions) GetFocusDir() (string, bool) {
 	if x.Verbose && willUseFocus {
 		x.Infof("Focusing on directory: %q", focus)
 	}
-	if !x.InvocationDirNotRecursive && !strings.HasSuffix(focus, "/...") {
+	if !x.NonRecursiveInvocationDir {
+		focus = ensureRecursivePath(focus)
 		focus = strings.TrimSuffix(focus, "/") // just in case
 		focus += "/..."
 	}

--- a/gomonorepo/c_format_modules.go
+++ b/gomonorepo/c_format_modules.go
@@ -58,7 +58,7 @@ func (x *formatModulesCommand) RunCommand(ctx context.Context, opts *AppOptions)
 }
 
 func (x *formatModulesCommand) runPerModule(ctx context.Context, m *Module) (commandResult, error) {
-	return x.runPerTarget(ctx, m.ModRoot)
+	return x.runPerTarget(ctx, ensureRecursivePath(m.ModRoot))
 }
 
 func (x *formatModulesCommand) runPerTarget(ctx context.Context, dir string) (commandResult, error) {

--- a/gomonorepo/c_generate_modules.go
+++ b/gomonorepo/c_generate_modules.go
@@ -59,7 +59,7 @@ func (x *genModulesCommand) RunCommand(ctx context.Context, opts *AppOptions) er
 }
 
 func (x *genModulesCommand) runPerModule(ctx context.Context, m *Module) (commandResult, error) {
-	return x.runPerTarget(ctx, m.ModRoot)
+	return x.runPerTarget(ctx, ensureRecursivePath(m.ModRoot))
 }
 
 func (x *genModulesCommand) runPerTarget(ctx context.Context, target string) (commandResult, error) {

--- a/gomonorepo/c_lint_modules.go
+++ b/gomonorepo/c_lint_modules.go
@@ -58,7 +58,7 @@ func (x *lintModulesCommand) RunCommand(ctx context.Context, opts *AppOptions) e
 }
 
 func (x *lintModulesCommand) runPerModule(ctx context.Context, m *Module) (commandResult, error) {
-	return x.runPerTarget(ctx, m.ModRoot)
+	return x.runPerTarget(ctx, ensureRecursivePath(m.ModRoot))
 }
 
 func (x *lintModulesCommand) runPerTarget(ctx context.Context, dir string) (commandResult, error) {

--- a/gomonorepo/c_test_modules.go
+++ b/gomonorepo/c_test_modules.go
@@ -58,7 +58,7 @@ func (x *testModulesCommand) RunCommand(ctx context.Context, opts *AppOptions) e
 }
 
 func (x *testModulesCommand) runPerModule(ctx context.Context, m *Module) (commandResult, error) {
-	return x.runPerTarget(ctx, m.ModRoot)
+	return x.runPerTarget(ctx, ensureRecursivePath(m.ModRoot))
 }
 
 func (x *testModulesCommand) runPerTarget(ctx context.Context, target string) (commandResult, error) {

--- a/gomonorepo/util.go
+++ b/gomonorepo/util.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/jessevdk/go-flags"
 	"golang.org/x/sync/semaphore"
@@ -111,4 +112,13 @@ func buildCommandName(cmd *exec.Cmd) string {
 	}
 
 	return sb.String()
+}
+
+func ensureRecursivePath(path string) string {
+	if strings.HasSuffix(path, "/...") {
+		return path
+	}
+	path = strings.TrimSuffix(path, "/") // just in case
+	path += "/..."
+	return path
 }


### PR DESCRIPTION
### Background

→ turns out we need to be recursive in other cases too.

### Changes

- ensure we always use recursive semantics when applicable

### Testing

- local