### PR TITLE
test args after test package kuz that's a thing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 .DS_Store
 bin
+go-coverage/

--- a/gomonorepo/c_test_modules.go
+++ b/gomonorepo/c_test_modules.go
@@ -3,6 +3,7 @@ package gomonorepo
 import (
 	"context"
 	"os"
+	"strings"
 )
 
 const testModulesDesc = `Invoke go tests in the mono repo.
@@ -25,7 +26,8 @@ var TestModulesCommand = &testModulesCommand{
 type testModulesCommand struct {
 	EmbeddedCommand
 	ParentCommitOpt
-	Fags []string `long:"flags" short:"f" description:"Flags to pass to through to the test command." default:"-race" default:"-count=1" default:"-cover"`
+	Fags []string `long:"flags" short:"f" description:"Flags to pass to through to the test command, these are passed in BEFORE the package list." default:"-race" default:"-count=1" default:"-cover"`
+	Args string   `long:"args" description:"Pass the remainder of the command line (everything after -args) to the test binary, uninterpreted and unchanged. This is passed AFTER the package list."`
 }
 
 func (x *testModulesCommand) RunCommand(ctx context.Context, opts *AppOptions) error {
@@ -67,5 +69,9 @@ func (x *testModulesCommand) runPerTarget(ctx context.Context, target string) (c
 	args[1] = "test"
 	args = append(args, x.Fags...)
 	args = append(args, ensureRecursivePath(target))
+	if x.Args != "" {
+		args = append(args, "-args")
+		args = append(args, strings.Fields(x.Args)...)
+	}
 	return runCommand(ctx, args), nil
 }


### PR DESCRIPTION
### Background

→ turns out go test args have to be supplied after the test package or everything breaks or it won't work

### Changes

-  ability to pass in test args after the package 

### Testing

- local